### PR TITLE
Added third party SKIA support for react-native-fast-image

### DIFF
--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -26,6 +26,8 @@ rn_cxx_component("fastImage") {
 
   # RNS Native module and its dependencies
   sources = [
+     "RSFastImageModule.h",
+     "RSFastImageModule.cpp",
   ]
 
   # RNS Fabric Component and its dependencies
@@ -44,6 +46,7 @@ rn_cxx_component("fastImage") {
   ]
 
   public_configs = [ ":LibFastImage_config" ]
+  public_configs += [ "//build/secondary/folly:folly_config" ]
   deps = [
     "//folly",
     "//folly:async",

--- a/skia/BUILD.gn
+++ b/skia/BUILD.gn
@@ -1,0 +1,57 @@
+##############################################################
+
+import("//react-native/common.gni")
+
+config("LibFastImage_config") {
+  cflags_cc = [ "-std=c++17"]
+  cflags_cc += [
+    "-Wno-extra-semi",
+    "-Wno-sign-compare",
+    "-Wno-header-hygiene",
+  ]
+
+  include_dirs = [".",
+                  "//react-native/",
+                  "//react-native/ReactCommon/",
+                  "//react-native/ReactCommon/jsi/",
+                  "//react-native/ReactCommon/react/renderer/graphics/platform/cxx",
+                  "//react-native/ReactCommon/yoga/",
+                  "//third_party/glog:glog",
+                  "//rns_shell/",
+                  "//ReactSkia/",
+                  ]
+}
+
+rn_cxx_component("fastImage") {
+
+  # RNS Native module and its dependencies
+  sources = [
+  ]
+
+  # RNS Fabric Component and its dependencies
+  sources += [
+    "RSkComponentProviderFastImage.cpp",
+    "RSkComponentProviderFastImage.h",
+    "RSkComponentFastImage.cpp",
+    "RSkComponentFastImage.h",
+    "react/renderer/components/fastImage/ReactNativeFastImageShadowNode.cpp",
+    "react/renderer/components/fastImage/ReactNativeFastImageProps.cpp",
+    "react/renderer/components/fastImage/ReactNativeFastImageEventEmitter.cpp",
+  ]
+
+  # FastImage cpp sources
+  sources += [
+  ]
+
+  public_configs = [ ":LibFastImage_config" ]
+  deps = [
+    "//folly",
+    "//folly:async",
+    "//skia",
+    "//react-native/ReactCommon/react/renderer/core:core",
+   
+  ]
+
+  with_exceptions = true
+  with_rtti = true
+}

--- a/skia/RSkComponentFastImage.cpp
+++ b/skia/RSkComponentFastImage.cpp
@@ -140,7 +140,8 @@ RnsShell::LayerInvalidateMask RSkComponentFastImage::updateComponentProps(const 
  }
 
 void RSkComponentFastImage::sendSuccessEvents() {
-   imageEventEmitter_->onLoad();
+   auto component = getComponentData();
+   imageEventEmitter_->onLoad(component.layoutMetrics.frame.size);
    imageEventEmitter_->onLoadEnd();
    hasToTriggerEvent_ = false;
  }

--- a/skia/RSkComponentFastImage.cpp
+++ b/skia/RSkComponentFastImage.cpp
@@ -1,0 +1,268 @@
+/*
+* Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+
+#include "include/core/SkPaint.h"
+#include "include/core/SkClipOp.h"
+#include "include/core/SkImageFilter.h"
+#include "include/core/SkMaskFilter.h"
+#include "include/effects/SkImageFilters.h"
+#include "src/core/SkMaskFilterBase.h"
+#include "rns_shell/compositor/layers/PictureLayer.h"
+#include "RSkComponentFastImage.h"
+#include "ReactSkia/views/common/RSkImageUtils.h"
+#include "ReactSkia/views/common/RSkConversion.h"
+
+namespace facebook {
+namespace react {
+
+using namespace RSkImageUtils;
+RSkComponentFastImage::RSkComponentFastImage(const ShadowView &shadowView)
+  : RSkComponentImage(shadowView) {
+       imageEventEmitter_ = std::static_pointer_cast<FastImageEventEmitter const>(shadowView.eventEmitter);
+}
+RSkComponentFastImage::~RSkComponentFastImage(){};
+
+void RSkComponentFastImage::OnPaint(SkCanvas *canvas) {
+  sk_sp<SkImage> imageData{nullptr};
+  string path;
+  auto component = getComponentData();
+  ReactNativeFastImageProps const &imageProps = *std::static_pointer_cast<ReactNativeFastImageProps const>(component.props);
+  //First to check file entry presence. If not exist, generate imageData.
+  do {
+    if(networkImageData_) {
+        imageData = networkImageData_;
+      break;
+    }
+    if(imageProps.sources.empty()) break;
+    imageData = RSkImageCacheManager::getImageCacheManagerInstance()->findImageDataInCache(imageProps.sources[0].uri.c_str());
+    if(imageData) break;
+    if (imageProps.sources[0].type == FastImageSource::Type::Local) {
+      imageData = getLocalImageData(imageProps.sources[0].uri.c_str());
+    } else if(imageProps.sources[0].type == FastImageSource::Type::Remote) {
+      requestNetworkImageData(imageProps.sources[0].uri.c_str());
+    }
+  } while(0);
+
+  Rect frame = component.layoutMetrics.frame;
+  SkRect frameRect = SkRect::MakeXYWH(frame.origin.x, frame.origin.y, frame.size.width, frame.size.height);
+  auto const &imageBorderMetrics=imageProps.resolveBorderMetrics(component.layoutMetrics);
+
+  // Draw order 1.Shadow 2. Background 3.Image Shadow 4. Image 5.Border
+  bool hollowFrame = false;
+  bool needClipAndRestore =false;
+  sk_sp<SkImageFilter> imageFilter;
+  auto  layerRef=layer();
+  if(layer()->isShadowVisible) {
+    /*Draw Shadow on Frame*/
+    hollowFrame=drawShadow(canvas,frame,imageBorderMetrics,
+                              imageProps.backgroundColor,
+                              layerRef->shadowColor,layerRef->shadowOffset,layerRef->shadowOpacity,
+                              layerRef->opacity,
+                              layerRef->shadowImageFilter,layerRef->shadowMaskFilter
+                          );
+  }
+  /*Draw Frame BackGround*/
+  drawBackground(canvas,frame,imageBorderMetrics,imageProps.backgroundColor);
+  if(imageData) {
+    SkRect imageTargetRect = computeTargetRect({imageData->width(),imageData->height()},frameRect,imageProps.resizeMode);
+    SkPaint paint;
+    /*Draw Image Shadow on below scenario:
+      ------------------------------------
+      1. Has visible shadow. but both border & background not avialble [case of ShadowDrawnMode::ShadowOnContent]
+      2. Shadow Drawn on Border[case of ShadowDrawnMode::ShadowOnBorder], But Image is either transparent  or smaller than the same
+    */
+    if(hollowFrame) {
+        //TODO: For the content Shadow, currently Shadow drawn for both Border[if avaialble] & Content[Image].
+        //      This behaviour to be cross verified with reference.
+      drawContentShadow(canvas,frameRect,imageTargetRect,imageData,imageProps,layerRef->shadowOffset,layerRef->shadowColor,layerRef->shadowOpacity);
+    }
+    /*Draw Image */
+    if(( frameRect.width() < imageTargetRect.width()) || ( frameRect.height() < imageTargetRect.height())) {
+      needClipAndRestore= true;
+    }
+    /* clipping logic to be applied if computed Frame is greater than the target.*/
+    if(needClipAndRestore) {
+        canvas->save();
+        canvas->clipRect(frameRect,SkClipOp::kIntersect);
+    }
+    /* TODO: Handle filter quality based of configuration. Setting Low Filter Quality as default for now*/
+    paint.setFilterQuality(DEFAULT_IMAGE_FILTER_QUALITY);
+    setPaintFilters(paint,imageProps,imageTargetRect,frameRect,false,imageData->isOpaque());
+    canvas->drawImageRect(imageData,imageTargetRect,&paint);
+    if(needClipAndRestore) {
+      canvas->restore();
+    }
+    networkImageData_ = nullptr;
+    drawBorder(canvas,frame,imageBorderMetrics,imageProps.backgroundColor);
+    // Emitting Load completed Event
+    if(hasToTriggerEvent_) sendSuccessEvents();
+
+  } else {
+  /* Emitting Image Load failed Event*/
+    if(imageProps.sources[0].type != FastImageSource::Type::Remote) {
+      if(!hasToTriggerEvent_) {
+        imageEventEmitter_->onLoadStart();
+        hasToTriggerEvent_ = true;
+      }
+      if(hasToTriggerEvent_) sendErrorEvents();
+      RNS_LOG_ERROR("Image not loaded :"<<imageProps.sources[0].uri.c_str());
+    }
+  }
+}
+
+void RSkComponentFastImage::drawAndSubmit() {
+  layer()->client().notifyFlushBegin();
+  layer()->invalidate( RnsShell::LayerPaintInvalidate);
+  if (layer()->type() == RnsShell::LAYER_TYPE_PICTURE) {
+    RNS_PROFILE_API_OFF(getComponentData().componentName << " getPicture :", static_cast<RnsShell::PictureLayer*>(layer().get())->setPicture(getPicture()));
+  }
+  layer()->client().notifyFlushRequired();
+}
+
+inline void RSkComponentFastImage::drawContentShadow( SkCanvas *canvas,
+                            SkRect frameRect,
+                            SkRect imageTargetRect,
+                            sk_sp<SkImage> imageData ,
+                            const ReactNativeFastImageProps  &imageProps,
+                            SkSize shadowOffset,
+                            SkColor shadowColor,
+                            float shadowOpacity){
+  /*TO DO :When Frame doesn't have background, has border with Jpeg Image and no resize.
+    currently drawing shadow for both border and content.
+    Need to cross verify with reference and confirm the behaviour.*/
+  SkRect shadowBounds;
+  SkIRect shadowFrame;
+  SkRect  frameBound;
+/*On below special cases, content Shadow to be drawn on complete frame/Layout instead on Image/content frame :
+  ------------------------------------------------------------------------------------------------------------
+   1. The target size of Image > Frame's size. In that case, clipping will be done to contain the image
+      within the frame, So shadow to be drawn conidering frame size.
+   2. For Repeat mode, Target frame size is the size of the frame itself.[Image will be repeated to fill the frame]
+*/
+  bool shadowOnFrame=(( frameRect.width() < imageTargetRect.width()) || ( frameRect.height() < imageTargetRect.height()));
+  if(shadowOnFrame) {
+    //Shadow on Frame Boundary
+    frameBound=frameRect;
+    shadowFrame.setXYWH(frameRect.x() + shadowOffset.width(), frameRect.y() + shadowOffset.height(), frameRect.width(), frameRect.height());
+  } else {
+    //Shadow on Image/Content Boundary
+    frameBound=imageTargetRect;
+    shadowFrame.setXYWH(imageTargetRect.x() + shadowOffset.width(), imageTargetRect.y() + shadowOffset.height(), imageTargetRect.width(), imageTargetRect.height());
+  }
+  SkIRect shadowIBounds=RSkDrawUtils::getShadowBounds(shadowFrame,layer()->shadowMaskFilter,layer()->shadowImageFilter);
+  shadowBounds=SkRect::Make(shadowIBounds);
+
+  bool saveLayerDone=false;
+//Apply Opacity
+  if(shadowOpacity) {
+    canvas->saveLayerAlpha(&shadowBounds,shadowOpacity);
+    saveLayerDone=true;
+  }
+
+  SkPaint shadowPaint;
+  setPaintFilters(shadowPaint,imageProps,imageTargetRect,frameRect,true,imageData->isOpaque());
+
+  if(!imageData->isOpaque() ) {
+//Apply Shadow for transparent image
+    canvas->drawImageRect(imageData, imageTargetRect, &shadowPaint);
+  } else {
+//Apply Shadow for opaque image
+    if(!saveLayerDone) {
+      canvas->saveLayer(&shadowBounds,&shadowPaint);
+      saveLayerDone =true;
+    }
+    // clipping done to avoid drawing on non visible area [Area under opque frame]
+    canvas->clipRect(frameBound,SkClipOp::kDifference);
+    shadowPaint.setColor(shadowColor);
+    canvas->drawIRect(shadowFrame, shadowPaint);
+  }
+  if(saveLayerDone) {
+    canvas->restore();
+  }
+#ifdef SHOW_SHADOW_BOUND
+  SkPaint paint;
+  paint.setStyle(SkPaint::kStroke_Style);
+  paint.setColor(SK_ColorGREEN);
+  paint.setStrokeWidth(2);
+  shadowBounds.join(frameBound);
+  canvas->drawRect(shadowBounds,paint);
+#endif
+}
+
+inline void RSkComponentFastImage::setPaintFilters (SkPaint &paintObj,const ReactNativeFastImageProps  &imageProps,
+                                                      SkRect imageTargetRect,SkRect frameRect ,
+                                                      bool  setFilterForShadow, bool opaqueImage) {
+  
+  //This function applies appropriate filter on paint to draw Shadow or Image.
+   /*  Image Filter will be used on below scenario :
+       -------------------------------------------
+      1. For shadow on Image with transparent pixel
+      2. For Image draw with Resize mide as "repeat"
+      3. For Image Draw with with blur Effect.
+   */
+  if((setFilterForShadow && !opaqueImage)||
+      (! setFilterForShadow &&
+         ((imageProps.blurRadius > 0))
+      )) {
+      sk_sp<SkImageFilter> shadowFilter{nullptr};
+      if(setFilterForShadow && (layer()->shadowImageFilter != nullptr) ) {
+         shadowFilter=layer()->shadowImageFilter;
+      }
+      if(imageProps.blurRadius > 0) {
+        shadowFilter = SkImageFilters::Blur(imageProps.blurRadius, imageProps.blurRadius,shadowFilter);
+      }
+      paintObj.setImageFilter(std::move(shadowFilter));
+   } else if(setFilterForShadow && (layer()->shadowMaskFilter != nullptr)) {
+      paintObj.setMaskFilter(layer()->shadowMaskFilter);
+  }
+}
+
+inline bool shouldCacheData(std::string cacheControlData) {
+  if(cacheControlData.find(RNS_NO_CACHE_STR) != std::string::npos) return false;
+  else if(cacheControlData.find(RNS_NO_STORE_STR) != std::string::npos) return false;
+  else if(cacheControlData.find(RNS_MAX_AGE_0_STR) != std::string::npos) return false;
+
+  return true;
+}
+
+RnsShell::LayerInvalidateMask RSkComponentFastImage::updateComponentProps(const ShadowView &newShadowView,bool forceUpdate) {
+
+    auto const &newimageProps = *std::static_pointer_cast<ReactNativeFastImageProps const>(newShadowView.props);
+    auto component = getComponentData();
+    auto const &oldimageProps = *std::static_pointer_cast<ReactNativeFastImageProps const>(component.props);
+    RnsShell::LayerInvalidateMask updateMask=RnsShell::LayerInvalidateNone;
+
+    if((forceUpdate) || (oldimageProps.resizeMode != newimageProps.resizeMode)) {
+      imageProps.resizeMode = newimageProps.resizeMode;
+      updateMask =static_cast<RnsShell::LayerInvalidateMask>(updateMask | RnsShell::LayerInvalidateAll);
+    }
+    if((forceUpdate) || (oldimageProps.tintColor != newimageProps.tintColor )) {
+      /* TODO : Needs implementation*/
+      imageProps.tintColor = RSkColorFromSharedColor(newimageProps.tintColor,SK_ColorTRANSPARENT);
+    }
+    if((forceUpdate) || (oldimageProps.sources[0].uri.compare(newimageProps.sources[0].uri) != 0)) {
+      imageEventEmitter_->onLoadStart();
+      hasToTriggerEvent_ = true;
+    }
+    return updateMask;
+}
+
+ void RSkComponentFastImage::sendErrorEvents() {
+   imageEventEmitter_->onError();
+   imageEventEmitter_->onLoadEnd();
+   hasToTriggerEvent_ = false;
+ }
+
+void RSkComponentFastImage::sendSuccessEvents() {
+   imageEventEmitter_->onLoad();
+   imageEventEmitter_->onLoadEnd();
+   hasToTriggerEvent_ = false;
+ }
+
+
+} // namespace react
+} // namespace facebook

--- a/skia/RSkComponentFastImage.h
+++ b/skia/RSkComponentFastImage.h
@@ -28,6 +28,7 @@ class RSkComponentFastImage final : public RSkComponentImage {
    std::shared_ptr<FastImageEventEmitter const> imageEventEmitter_;
    sk_sp<SkImage> networkImageData_{nullptr};
    bool processImageData(const char* path, char* response, int size) override;
+   void requestNetworkImageData(std::string uri);
    void sendErrorEvents() override;
    void sendSuccessEvents() override;
  protected:

--- a/skia/RSkComponentFastImage.h
+++ b/skia/RSkComponentFastImage.h
@@ -6,45 +6,31 @@
 */
 #pragma once
 
-#include "include/core/SkRect.h"
-#include "external/react-native-fast-image/skia/react/renderer/components/fastImage/ReactNativeFastImageShadowNode.h"
-#include "external/react-native-fast-image/skia/react/renderer/components/fastImage/ReactNativeFastImageEventEmitter.h"
-#include "ReactSkia/components/RSkComponent.h"
 #include "ReactSkia/components/RSkComponentImage.h"
-#include "ReactSkia/views/common/RSkImageCacheManager.h"
+
+#include "react/renderer/components/fastImage/ReactNativeFastImageShadowNode.h"
 
 namespace facebook {
 namespace react {
 
 struct FastImgProps{
-    FastImageResizeMode resizeMode;
+    ImageResizeMode resizeMode;
     SkColor tintColor;
 };
-class RSkComponentFastImage : public RSkComponentImage {
+
+class RSkComponentFastImage final : public RSkComponentImage {
  public:
    RSkComponentFastImage(const ShadowView &shadowView);
    ~RSkComponentFastImage();
    RnsShell::LayerInvalidateMask updateComponentProps(const ShadowView &newShadowView,bool forceUpdate) override;
  private:
-  FastImgProps imageProps;
-  std::shared_ptr<FastImageEventEmitter const> imageEventEmitter_;
-  sk_sp<SkImage> networkImageData_{nullptr};
-  inline void drawContentShadow(SkCanvas *canvas,
-                              SkRect frameRect,/*actual image frame*/
-                              SkRect imageTargetRect,/*area of draw image and shadow*/
-                              sk_sp<SkImage> imageData,
-                              const ReactNativeFastImageProps  &imageProps,
-                              SkSize shadowOffset,
-                              SkColor shadowColor,
-                              float shadowOpacity);
-  inline void setPaintFilters (SkPaint &paintObj,const ReactNativeFastImageProps  &imageProps,
-                              SkRect targetRect,SkRect frameRect,
-                              bool  filterForShadow, bool isOpaque);
+   FastImgProps imageProps;
+   std::shared_ptr<FastImageEventEmitter const> imageEventEmitter_;
+   sk_sp<SkImage> networkImageData_{nullptr};
    void sendErrorEvents() override;
    void sendSuccessEvents() override;
-   void drawAndSubmit() override;
  protected:
-  void OnPaint(SkCanvas *canvas) override;
+   void OnPaint(SkCanvas *canvas) override;
 };
 
 } // namespace react

--- a/skia/RSkComponentFastImage.h
+++ b/skia/RSkComponentFastImage.h
@@ -7,7 +7,7 @@
 #pragma once
 
 #include "ReactSkia/components/RSkComponentImage.h"
-
+#include "ReactSkia/views/common/RSkImageCacheManager.h"
 #include "react/renderer/components/fastImage/ReactNativeFastImageShadowNode.h"
 
 namespace facebook {
@@ -27,6 +27,7 @@ class RSkComponentFastImage final : public RSkComponentImage {
    FastImgProps imageProps;
    std::shared_ptr<FastImageEventEmitter const> imageEventEmitter_;
    sk_sp<SkImage> networkImageData_{nullptr};
+   bool processImageData(const char* path, char* response, int size) override;
    void sendErrorEvents() override;
    void sendSuccessEvents() override;
  protected:

--- a/skia/RSkComponentFastImage.h
+++ b/skia/RSkComponentFastImage.h
@@ -1,0 +1,51 @@
+/*
+* Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
+#pragma once
+
+#include "include/core/SkRect.h"
+#include "external/react-native-fast-image/skia/react/renderer/components/fastImage/ReactNativeFastImageShadowNode.h"
+#include "external/react-native-fast-image/skia/react/renderer/components/fastImage/ReactNativeFastImageEventEmitter.h"
+#include "ReactSkia/components/RSkComponent.h"
+#include "ReactSkia/components/RSkComponentImage.h"
+#include "ReactSkia/views/common/RSkImageCacheManager.h"
+
+namespace facebook {
+namespace react {
+
+struct FastImgProps{
+    FastImageResizeMode resizeMode;
+    SkColor tintColor;
+};
+class RSkComponentFastImage : public RSkComponentImage {
+ public:
+   RSkComponentFastImage(const ShadowView &shadowView);
+   ~RSkComponentFastImage();
+   RnsShell::LayerInvalidateMask updateComponentProps(const ShadowView &newShadowView,bool forceUpdate) override;
+ private:
+  FastImgProps imageProps;
+  std::shared_ptr<FastImageEventEmitter const> imageEventEmitter_;
+  sk_sp<SkImage> networkImageData_{nullptr};
+  inline void drawContentShadow(SkCanvas *canvas,
+                              SkRect frameRect,/*actual image frame*/
+                              SkRect imageTargetRect,/*area of draw image and shadow*/
+                              sk_sp<SkImage> imageData,
+                              const ReactNativeFastImageProps  &imageProps,
+                              SkSize shadowOffset,
+                              SkColor shadowColor,
+                              float shadowOpacity);
+  inline void setPaintFilters (SkPaint &paintObj,const ReactNativeFastImageProps  &imageProps,
+                              SkRect targetRect,SkRect frameRect,
+                              bool  filterForShadow, bool isOpaque);
+   void sendErrorEvents() override;
+   void sendSuccessEvents() override;
+   void drawAndSubmit() override;
+ protected:
+  void OnPaint(SkCanvas *canvas) override;
+};
+
+} // namespace react
+} // namespace facebook

--- a/skia/RSkComponentProviderFastImage.cpp
+++ b/skia/RSkComponentProviderFastImage.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#include "external/react-native-fast-image/skia/RSkComponentProviderFastImage.h"
+#include "external/react-native-fast-image/skia/RSkComponentFastImage.h"
+#include "external/react-native-fast-image/skia/react/renderer/components/fastImage/ReactNativeFastImageDescriptor.h"
+
+namespace facebook {
+namespace react {
+
+RSkComponentProviderFastImage::RSkComponentProviderFastImage() {}
+
+ComponentDescriptorProvider RSkComponentProviderFastImage::GetDescriptorProvider() {
+  return concreteComponentDescriptorProvider<ReactNativeFastImageComponentDescriptor>();
+}
+
+std::shared_ptr<RSkComponent> RSkComponentProviderFastImage::CreateComponent(
+    const ShadowView &shadowView) {
+  return std::static_pointer_cast<RSkComponent>(
+      std::make_shared<RSkComponentFastImage>(shadowView));
+}
+
+} // namespace react
+} // namespace facebook

--- a/skia/RSkComponentProviderFastImage.cpp
+++ b/skia/RSkComponentProviderFastImage.cpp
@@ -5,9 +5,9 @@
  * found in the LICENSE file.
  */
 
-#include "external/react-native-fast-image/skia/RSkComponentProviderFastImage.h"
-#include "external/react-native-fast-image/skia/RSkComponentFastImage.h"
-#include "external/react-native-fast-image/skia/react/renderer/components/fastImage/ReactNativeFastImageDescriptor.h"
+#include "RSkComponentProviderFastImage.h"
+#include "RSkComponentFastImage.h"
+#include "react/renderer/components/fastImage/ReactNativeFastImageDescriptor.h"
 
 namespace facebook {
 namespace react {

--- a/skia/RSkComponentProviderFastImage.cpp
+++ b/skia/RSkComponentProviderFastImage.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+ * Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
  *
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.

--- a/skia/RSkComponentProviderFastImage.h
+++ b/skia/RSkComponentProviderFastImage.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+ * Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
  *
  * Use of this source code is governed by a BSD-style license that can be
  * found in the LICENSE file.

--- a/skia/RSkComponentProviderFastImage.h
+++ b/skia/RSkComponentProviderFastImage.h
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) 1994-2021 OpenTV, Inc. and Nagravision S.A.
+ *
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#pragma once
+
+#include "ReactSkia/components/RSkComponentProvider.h"
+
+namespace facebook {
+namespace react {
+
+class RSkComponentProviderFastImage : public RSkComponentProvider {
+ public:
+  RSkComponentProviderFastImage();
+
+ public:
+  ComponentDescriptorProvider GetDescriptorProvider() override;
+  std::shared_ptr<RSkComponent> CreateComponent(
+      const ShadowView &shadowView) override;
+};
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+RNS_USED RSkComponentProvider *RSkComponentProviderFastImageCls() {
+  return new RSkComponentProviderFastImage();
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+} // namespace react
+} // namespace facebook

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageDescriptor.h
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageDescriptor.h
@@ -1,0 +1,19 @@
+/*
+ * Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "react/renderer/core/ConcreteComponentDescriptor.h"
+#include "ReactNativeFastImageShadowNode.h"
+
+namespace facebook {
+namespace react {
+
+using ReactNativeFastImageComponentDescriptor = ConcreteComponentDescriptor<ReactNativeFastImageShadowNode>;
+
+} // namespace react
+} // namespace facebook

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageEventEmitter.cpp
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageEventEmitter.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ReactNativeFastImageEventEmitter.h"
+
+namespace facebook {
+namespace react {
+
+void FastImageEventEmitter::onLoadStart() const {
+  dispatchEvent("onFastImageLoadStart");
+}
+
+void FastImageEventEmitter::onLoad() const {
+  dispatchEvent("onFastImageLoad");
+}
+
+void FastImageEventEmitter::onLoadEnd() const {
+  dispatchEvent("onFastImageLoadEnd");
+}
+
+void FastImageEventEmitter::onProgress(double progress) const {
+  dispatchEvent("progress", [=](jsi::Runtime &runtime) {
+    auto payload = jsi::Object(runtime);
+    payload.setProperty(runtime, "progress", progress);
+    return payload;
+  });
+}
+
+void FastImageEventEmitter::onError() const {
+  dispatchEvent("onFastImageError");
+}
+
+} // namespace react
+} // namespace facebook

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageEventEmitter.cpp
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageEventEmitter.cpp
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
+* Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
 
 #include "ReactNativeFastImageEventEmitter.h"
 
@@ -14,8 +14,13 @@ void FastImageEventEmitter::onLoadStart() const {
   dispatchEvent("onFastImageLoadStart");
 }
 
-void FastImageEventEmitter::onLoad() const {
-  dispatchEvent("onFastImageLoad");
+void FastImageEventEmitter::onLoad(Size size) const {
+  dispatchEvent("onFastImageLoad", [=](jsi::Runtime &runtime) {
+    auto payload = jsi::Object(runtime);
+    payload.setProperty(runtime, "width", size.width);
+    payload.setProperty(runtime, "height", size.height);
+    return payload;
+  });
 }
 
 void FastImageEventEmitter::onLoadEnd() const {

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageEventEmitter.h
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageEventEmitter.h
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <react/renderer/components/view/ViewEventEmitter.h>
+
+namespace facebook {
+namespace react {
+
+class FastImageEventEmitter : public ViewEventEmitter {
+ public:
+  using ViewEventEmitter::ViewEventEmitter;
+
+  void onLoadStart() const;
+  void onLoad() const;
+  void onLoadEnd() const;
+  void onProgress(double) const;
+  void onError() const;
+  void onPartialLoad() const;
+};
+
+} // namespace react
+} // namespace facebook

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageEventEmitter.h
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageEventEmitter.h
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
+* Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
 
 #pragma once
 
@@ -17,7 +17,7 @@ class FastImageEventEmitter : public ViewEventEmitter {
   using ViewEventEmitter::ViewEventEmitter;
 
   void onLoadStart() const;
-  void onLoad() const;
+  void onLoad(Size) const;
   void onLoadEnd() const;
   void onProgress(double) const;
   void onError() const;

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.cpp
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.cpp
@@ -5,9 +5,10 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+#include <react/renderer/core/propsConversions.h>
+
 #include "ReactNativeFastImageProps.h"
 #include "conversions.h"
-#include <react/renderer/core/propsConversions.h>
 
 namespace facebook {
 namespace react {
@@ -24,7 +25,7 @@ ReactNativeFastImageProps::ReactNativeFastImageProps(const ReactNativeFastImageP
           rawProps,
           "resizeMode",
           sourceProps.resizeMode,
-          FastImageResizeMode::Stretch)),
+          ImageResizeMode::Stretch)),
       blurRadius(
           convertRawProp(rawProps, "blurRadius", sourceProps.blurRadius, {})),
       capInsets(

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.cpp
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include "ReactNativeFastImageProps.h"
+#include "conversions.h"
+#include <react/renderer/core/propsConversions.h>
+
+namespace facebook {
+namespace react {
+
+ReactNativeFastImageProps::ReactNativeFastImageProps(const ReactNativeFastImageProps &sourceProps, const RawProps &rawProps)
+    : ViewProps(sourceProps, rawProps),
+        sources(convertRawProp(rawProps, "source", sourceProps.sources, {})),
+      defaultSources(convertRawProp(
+          rawProps,
+          "defaultSource",
+          sourceProps.defaultSources,
+          {})),
+      resizeMode(convertRawProp(
+          rawProps,
+          "resizeMode",
+          sourceProps.resizeMode,
+          FastImageResizeMode::Stretch)),
+      blurRadius(
+          convertRawProp(rawProps, "blurRadius", sourceProps.blurRadius, {})),
+      capInsets(
+          convertRawProp(rawProps, "capInsets", sourceProps.capInsets, {})),
+      tintColor(
+          convertRawProp(rawProps, "tintColor", sourceProps.tintColor, {})),
+      internal_analyticTag(convertRawProp(
+          rawProps,
+          "internal_analyticTag",
+          sourceProps.internal_analyticTag,
+          {})) {}
+
+} // namespace react
+} // namespace facebook

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.cpp
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.cpp
@@ -8,6 +8,7 @@
 #include <react/renderer/core/propsConversions.h>
 
 #include "ReactNativeFastImageProps.h"
+#include <react/renderer/components/image/conversions.h>
 #include "conversions.h"
 
 namespace facebook {
@@ -26,17 +27,9 @@ ReactNativeFastImageProps::ReactNativeFastImageProps(const ReactNativeFastImageP
           "resizeMode",
           sourceProps.resizeMode,
           ImageResizeMode::Stretch)),
-      blurRadius(
-          convertRawProp(rawProps, "blurRadius", sourceProps.blurRadius, {})),
-      capInsets(
-          convertRawProp(rawProps, "capInsets", sourceProps.capInsets, {})),
       tintColor(
-          convertRawProp(rawProps, "tintColor", sourceProps.tintColor, {})),
-      internal_analyticTag(convertRawProp(
-          rawProps,
-          "internal_analyticTag",
-          sourceProps.internal_analyticTag,
-          {})) {}
+          convertRawProp(rawProps, "tintColor", sourceProps.tintColor, {}))
+           {}
 
 } // namespace react
 } // namespace facebook

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.h
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#include <react/renderer/components/view/ViewProps.h>
+#include "external/react-native-fast-image/skia/react/renderer/fastImageManager/primitives.h"
+namespace facebook {
+namespace react {
+
+// TODO (T28334063): Consider for codegen.
+class ReactNativeFastImageProps final : public ViewProps {
+ public:
+  ReactNativeFastImageProps() = default;
+  ReactNativeFastImageProps(const ReactNativeFastImageProps &sourceProps, const RawProps &rawProps);
+
+#pragma mark - Props
+
+  const FastImageSources sources{};
+  const FastImageSources defaultSources{};
+  const FastImageResizeMode resizeMode{FastImageResizeMode::Stretch};
+  const Float blurRadius{};
+  const EdgeInsets capInsets{};
+  const SharedColor tintColor{};
+  const std::string internal_analyticTag{};
+};
+
+} // namespace react
+} // namespace facebook

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.h
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.h
@@ -4,9 +4,13 @@
  * This source code is licensed under the MIT license found in the
  * LICENSE file in the root directory of this source tree.
  */
+#pragma once
 
 #include <react/renderer/components/view/ViewProps.h>
+#include "react/renderer/components/image/ImageShadowNode.h"
+
 #include "external/react-native-fast-image/skia/react/renderer/fastImageManager/primitives.h"
+
 namespace facebook {
 namespace react {
 
@@ -20,7 +24,7 @@ class ReactNativeFastImageProps final : public ViewProps {
 
   const FastImageSources sources{};
   const FastImageSources defaultSources{};
-  const FastImageResizeMode resizeMode{FastImageResizeMode::Stretch};
+  const ImageResizeMode resizeMode{ImageResizeMode::Stretch};
   const Float blurRadius{};
   const EdgeInsets capInsets{};
   const SharedColor tintColor{};

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.h
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageProps.h
@@ -25,10 +25,7 @@ class ReactNativeFastImageProps final : public ViewProps {
   const FastImageSources sources{};
   const FastImageSources defaultSources{};
   const ImageResizeMode resizeMode{ImageResizeMode::Stretch};
-  const Float blurRadius{};
-  const EdgeInsets capInsets{};
   const SharedColor tintColor{};
-  const std::string internal_analyticTag{};
 };
 
 } // namespace react

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageShadowNode.cpp
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageShadowNode.cpp
@@ -1,0 +1,16 @@
+/*
+ * Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+#include <react/renderer/core/LayoutContext.h>
+#include "ReactNativeFastImageShadowNode.h"
+
+namespace facebook {
+namespace react {
+
+extern const char ReactNativeFastImageComponentName[] = "FastImageView";
+
+} // namespace react
+} // namespace facebook

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageShadowNode.h
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageShadowNode.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include "react/renderer/components/view/ConcreteViewShadowNode.h"
+#include "ReactNativeFastImageEventEmitter.h"
+#include "ReactNativeFastImageProps.h"
+#include "ReactNativeFastImageState.h"
+#include "external/react-native-fast-image/skia/react/renderer/fastImageManager/primitives.h"
+
+namespace facebook {
+namespace react {
+
+extern const char ReactNativeFastImageComponentName[];
+
+/*
+* `ShadowNode` for <ReactNativeFastImage> component.
+*/
+using ReactNativeFastImageShadowNode = ConcreteViewShadowNode<
+    ReactNativeFastImageComponentName,
+    ReactNativeFastImageProps,
+    FastImageEventEmitter,
+    ReactNativeFastImageState>;
+
+} // namespace react
+} // namespace facebook

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageState.h
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageState.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+namespace facebook {
+namespace react {
+
+/*
+ * State for <ReactNativeFastImage> component.
+ */
+class ReactNativeFastImageState final {
+ public:
+  ReactNativeFastImageState() {}
+  /*
+   * Returns stored ImageSource object.
+   */
+  FastImageSource getImageSource() const;
+
+  /*
+   * Exposes for reading stored `ImageRequest` object.
+   * `ImageRequest` object cannot be copied or moved from `ImageLocalData`.
+   */
+
+  Float getBlurRadius() const;
+  #ifdef ANDROID
+  ReactNativeFastImageState(ReactNativeFastImageState const &previousState, folly::dynamic data)
+      : blurRadius_{0} {};
+
+  /*
+   * Empty implementation for Android because it doesn't use this class.
+   */
+  folly::dynamic getDynamic() const {
+    return {};
+  };
+#endif
+
+ private:
+  FastImageSource imageSource_;
+
+};
+
+} // namespace react
+} // namespace facebook

--- a/skia/react/renderer/components/fastImage/ReactNativeFastImageState.h
+++ b/skia/react/renderer/components/fastImage/ReactNativeFastImageState.h
@@ -17,7 +17,7 @@ class ReactNativeFastImageState final {
  public:
   ReactNativeFastImageState() {}
   /*
-   * Returns stored ImageSource object.
+   * Returns stored fastImageSource object.
    */
   FastImageSource getImageSource() const;
 

--- a/skia/react/renderer/components/fastImage/conversions.h
+++ b/skia/react/renderer/components/fastImage/conversions.h
@@ -1,0 +1,126 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <better/map.h>
+#include <folly/dynamic.h>
+#include <react/renderer/graphics/conversions.h>
+#include "external/react-native-fast-image/skia/react/renderer/fastImageManager/primitives.h"
+
+namespace facebook {
+namespace react {
+
+inline void fromRawValue(const RawValue &value, FastImageSource &result) {
+  if (value.hasType<std::string>()) {
+    result = {
+        /* .type = */ FastImageSource::Type::Remote,
+        /* .uri = */ (std::string)value,
+    };
+    return;
+  }
+
+  if (value.hasType<better::map<std::string, RawValue>>()) {
+    auto items = (better::map<std::string, RawValue>)value;
+    result = {};
+
+    result.type = FastImageSource::Type::Remote;
+
+    if (items.find("__packager_asset") != items.end()) {
+      result.type = FastImageSource::Type::Local;
+    }
+
+    if (items.find("width") != items.end() &&
+        items.find("height") != items.end() &&
+        // The following checks have to be removed after codegen is shipped.
+        // See T45151459.
+        items.at("width").hasType<Float>() &&
+        items.at("height").hasType<Float>()) {
+      result.size = {(Float)items.at("width"), (Float)items.at("height")};
+    }
+
+    if (items.find("scale") != items.end() &&
+        // The following checks have to be removed after codegen is shipped.
+        // See T45151459.
+        items.at("scale").hasType<Float>()) {
+      result.scale = (Float)items.at("scale");
+    } else {
+      result.scale = items.find("deprecated") != items.end() ? 0.0 : 1.0;
+    }
+
+    if (items.find("url") != items.end() &&
+        // The following should be removed after codegen is shipped.
+        // See T45151459.
+        items.at("url").hasType<std::string>()) {
+      result.uri = (std::string)items.at("url");
+    }
+
+    if (items.find("uri") != items.end() &&
+        // The following should be removed after codegen is shipped.
+        // See T45151459.
+        items.at("uri").hasType<std::string>()) {
+      result.uri = (std::string)items.at("uri");
+    }
+
+    if (items.find("bundle") != items.end() &&
+        // The following should be removed after codegen is shipped.
+        // See T45151459.
+        items.at("bundle").hasType<std::string>()) {
+      result.bundle = (std::string)items.at("bundle");
+      result.type = FastImageSource::Type::Local;
+    }
+
+    return;
+  }
+
+  // The following should be removed after codegen is shipped.
+  // See T45151459.
+  result = {};
+  result.type = FastImageSource::Type::Invalid;
+}
+
+inline std::string toString(const FastImageSource &value) {
+  return "{uri: " + value.uri + "}";
+}
+
+inline void fromRawValue(const RawValue &value, FastImageResizeMode &result) {
+  assert(value.hasType<std::string>());
+  auto stringValue = (std::string)value;
+  if (stringValue == "cover") {
+    result = FastImageResizeMode::Cover;
+    return;
+  }
+  if (stringValue == "contain") {
+    result = FastImageResizeMode::Contain;
+    return;
+  }
+  if (stringValue == "stretch") {
+    result = FastImageResizeMode::Stretch;
+    return;
+  }
+  if (stringValue == "center") {
+    result = FastImageResizeMode::Center;
+    return;
+  }
+  abort();
+}
+
+inline std::string toString(const FastImageResizeMode &value) {
+  switch (value) {
+    case FastImageResizeMode::Cover:
+      return "cover";
+    case FastImageResizeMode::Contain:
+      return "contain";
+    case FastImageResizeMode::Stretch:
+      return "stretch";
+    case FastImageResizeMode::Center:
+      return "center";
+  }
+}
+
+} // namespace react
+} // namespace facebook

--- a/skia/react/renderer/components/fastImage/conversions.h
+++ b/skia/react/renderer/components/fastImage/conversions.h
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
+* Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
 
 #pragma once
 
@@ -87,38 +87,44 @@ inline std::string toString(const FastImageSource &value) {
   return "{uri: " + value.uri + "}";
 }
 
-inline void fromRawValue(const RawValue &value, FastImageResizeMode &result) {
+inline void fromRawValue(const RawValue &value, ImageResizeMode &result) {
   assert(value.hasType<std::string>());
   auto stringValue = (std::string)value;
   if (stringValue == "cover") {
-    result = FastImageResizeMode::Cover;
+    result = ImageResizeMode::Cover;
     return;
   }
   if (stringValue == "contain") {
-    result = FastImageResizeMode::Contain;
+    result = ImageResizeMode::Contain;
     return;
   }
   if (stringValue == "stretch") {
-    result = FastImageResizeMode::Stretch;
+    result = ImageResizeMode::Stretch;
     return;
   }
   if (stringValue == "center") {
-    result = FastImageResizeMode::Center;
+    result = ImageResizeMode::Center;
+    return;
+  }
+  if (stringValue == "repeat") {
+    result = ImageResizeMode::Repeat;
     return;
   }
   abort();
 }
 
-inline std::string toString(const FastImageResizeMode &value) {
+inline std::string toString(const ImageResizeMode &value) {
   switch (value) {
-    case FastImageResizeMode::Cover:
+    case ImageResizeMode::Cover:
       return "cover";
-    case FastImageResizeMode::Contain:
+    case ImageResizeMode::Contain:
       return "contain";
-    case FastImageResizeMode::Stretch:
+    case ImageResizeMode::Stretch:
       return "stretch";
-    case FastImageResizeMode::Center:
+    case ImageResizeMode::Center:
       return "center";
+    case ImageResizeMode::Repeat:
+      return "repeat";
   }
 }
 

--- a/skia/react/renderer/components/fastImage/conversions.h
+++ b/skia/react/renderer/components/fastImage/conversions.h
@@ -11,47 +11,14 @@
 #include <folly/dynamic.h>
 #include <react/renderer/graphics/conversions.h>
 #include "external/react-native-fast-image/skia/react/renderer/fastImageManager/primitives.h"
-
 namespace facebook {
 namespace react {
 
 inline void fromRawValue(const RawValue &value, FastImageSource &result) {
-  if (value.hasType<std::string>()) {
-    result = {
-        /* .type = */ FastImageSource::Type::Remote,
-        /* .uri = */ (std::string)value,
-    };
-    return;
-  }
 
-  if (value.hasType<better::map<std::string, RawValue>>()) {
+   if (value.hasType<better::map<std::string, RawValue>>()) {
     auto items = (better::map<std::string, RawValue>)value;
     result = {};
-
-    result.type = FastImageSource::Type::Remote;
-
-    if (items.find("__packager_asset") != items.end()) {
-      result.type = FastImageSource::Type::Local;
-    }
-
-    if (items.find("width") != items.end() &&
-        items.find("height") != items.end() &&
-        // The following checks have to be removed after codegen is shipped.
-        // See T45151459.
-        items.at("width").hasType<Float>() &&
-        items.at("height").hasType<Float>()) {
-      result.size = {(Float)items.at("width"), (Float)items.at("height")};
-    }
-
-    if (items.find("scale") != items.end() &&
-        // The following checks have to be removed after codegen is shipped.
-        // See T45151459.
-        items.at("scale").hasType<Float>()) {
-      result.scale = (Float)items.at("scale");
-    } else {
-      result.scale = items.find("deprecated") != items.end() ? 0.0 : 1.0;
-    }
-
     if (items.find("url") != items.end() &&
         // The following should be removed after codegen is shipped.
         // See T45151459.
@@ -66,66 +33,35 @@ inline void fromRawValue(const RawValue &value, FastImageSource &result) {
       result.uri = (std::string)items.at("uri");
     }
 
-    if (items.find("bundle") != items.end() &&
-        // The following should be removed after codegen is shipped.
-        // See T45151459.
-        items.at("bundle").hasType<std::string>()) {
-      result.bundle = (std::string)items.at("bundle");
-      result.type = FastImageSource::Type::Local;
+    if (items.find("priority") != items.end() &&
+      items.at("priority").hasType<std::string>()) {
+      auto stringValue = (std::string)items.at("priority");
+      if(stringValue == "low") {
+        result.priority = FastImageSource::Priority::low;
+      } else if (stringValue == "normal") {
+        result.priority = FastImageSource::Priority::normal;
+      }else if (stringValue == "high") {
+        result.priority = FastImageSource::Priority::high;
+      }
     }
 
+    if (items.find("cache") != items.end() &&
+      items.at("cache").hasType<std::string>()) {
+      auto stringValue = (std::string)items.at("cache");
+      if(stringValue == "immutable") {
+        result.cache = FastImageSource::Cache::immutable;
+      } else if (stringValue == "web") {
+        result.cache = FastImageSource::Cache::web;
+      }else if (stringValue == "cacheOnly") {
+        result.cache = FastImageSource::Cache::cacheOnly;
+      }
+    }
     return;
   }
 
   // The following should be removed after codegen is shipped.
   // See T45151459.
   result = {};
-  result.type = FastImageSource::Type::Invalid;
-}
-
-inline std::string toString(const FastImageSource &value) {
-  return "{uri: " + value.uri + "}";
-}
-
-inline void fromRawValue(const RawValue &value, ImageResizeMode &result) {
-  assert(value.hasType<std::string>());
-  auto stringValue = (std::string)value;
-  if (stringValue == "cover") {
-    result = ImageResizeMode::Cover;
-    return;
-  }
-  if (stringValue == "contain") {
-    result = ImageResizeMode::Contain;
-    return;
-  }
-  if (stringValue == "stretch") {
-    result = ImageResizeMode::Stretch;
-    return;
-  }
-  if (stringValue == "center") {
-    result = ImageResizeMode::Center;
-    return;
-  }
-  if (stringValue == "repeat") {
-    result = ImageResizeMode::Repeat;
-    return;
-  }
-  abort();
-}
-
-inline std::string toString(const ImageResizeMode &value) {
-  switch (value) {
-    case ImageResizeMode::Cover:
-      return "cover";
-    case ImageResizeMode::Contain:
-      return "contain";
-    case ImageResizeMode::Stretch:
-      return "stretch";
-    case ImageResizeMode::Center:
-      return "center";
-    case ImageResizeMode::Repeat:
-      return "repeat";
-  }
 }
 
 } // namespace react

--- a/skia/react/renderer/fastImageManager/primitives.h
+++ b/skia/react/renderer/fastImageManager/primitives.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <react/renderer/graphics/Geometry.h>
+
+namespace facebook {
+namespace react {
+
+class FastImageSource {
+ public:
+  enum class Type { Invalid, Remote, Local };
+
+  Type type{};
+  std::string uri{};
+  std::string bundle{};
+  Float scale{3};
+  Size size{0};
+
+  bool operator==(const FastImageSource &rhs) const {
+    return std::tie(this->type, this->uri,this->size) == std::tie(rhs.type, rhs.uri,rhs.size);
+  }
+
+  bool operator!=(const FastImageSource &rhs) const {
+    return !(*this == rhs);
+  }
+};
+
+using FastImageSources = std::vector<FastImageSource>;
+
+enum class FastImageResizeMode {
+  Cover,
+  Contain,
+  Stretch,
+  Center,
+};
+
+} // namespace react
+} // namespace facebook

--- a/skia/react/renderer/fastImageManager/primitives.h
+++ b/skia/react/renderer/fastImageManager/primitives.h
@@ -1,9 +1,9 @@
 /*
- * Copyright (c) Facebook, Inc. and its affiliates.
- *
- * This source code is licensed under the MIT license found in the
- * LICENSE file in the root directory of this source tree.
- */
+* Copyright (C) 1994-2022 OpenTV, Inc. and Nagravision S.A.
+*
+* This source code is licensed under the MIT license found in the
+* LICENSE file in the root directory of this source tree.
+*/
 
 #pragma once
 
@@ -35,13 +35,6 @@ class FastImageSource {
 };
 
 using FastImageSources = std::vector<FastImageSource>;
-
-enum class FastImageResizeMode {
-  Cover,
-  Contain,
-  Stretch,
-  Center,
-};
 
 } // namespace react
 } // namespace facebook

--- a/skia/react/renderer/fastImageManager/primitives.h
+++ b/skia/react/renderer/fastImageManager/primitives.h
@@ -17,21 +17,12 @@ namespace react {
 
 class FastImageSource {
  public:
-  enum class Type { Invalid, Remote, Local };
-
-  Type type{};
+  enum class Priority { low, normal, high };
+  enum class Cache { immutable, web, cacheOnly };
   std::string uri{};
-  std::string bundle{};
-  Float scale{3};
-  Size size{0};
+  Priority priority{};
+  Cache cache{};
 
-  bool operator==(const FastImageSource &rhs) const {
-    return std::tie(this->type, this->uri,this->size) == std::tie(rhs.type, rhs.uri,rhs.size);
-  }
-
-  bool operator!=(const FastImageSource &rhs) const {
-    return !(*this == rhs);
-  }
 };
 
 using FastImageSources = std::vector<FastImageSource>;


### PR DESCRIPTION
Create, Register, and support react-native-fastimage third party component in RNS.
Supported Properties and Events.
1. Style props
2. Source
3. source.uri
4. resizeMode(contain,cover,stretch,center )
5. Events (onFastImageLoadStart, onFastImageProgress,onFastImageError,onFastImageLoad,onFastImageLoadEnd).